### PR TITLE
Add Vaadin 25 support while maintaining Vaadin 24 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,8 @@
 										<exclude>**/test/*</exclude>
 										<exclude>**/it/*</exclude>
 										<exclude>**/DemoView.class</exclude>
-										<exclude>**/DemoLayout.class</exclude>
+										<exclude>**/DemoLayout.class</exclude>										
+										<exclude>**/AppShellConfiguratorImpl.class</exclude>
 									</excludes>
 								</configuration>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
 			<properties>
 				<maven.compiler.source>21</maven.compiler.source>
 				<maven.compiler.target>21</maven.compiler.target>
-				<vaadin.version>25.0.0</vaadin.version>
+				<vaadin.version>25.0.6</vaadin.version>
 				<jetty.version>11.0.26</jetty.version>
 			</properties>
 			<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
 			<artifactId>vaadin-testbench</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+            <groupId>com.flowingcode.vaadin.test</groupId>
+            <artifactId>testbench-rpc</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
 			<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 			<artifactId>commons-demo</artifactId>

--- a/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/LoginLayout.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/LoginLayout.java
@@ -51,14 +51,17 @@ public class LoginLayout extends LoginOverlay implements RouterLayout, Replaceab
   protected void onAttach(AttachEvent attachEvent) {
     super.onAttach(attachEvent);
     setOpened(true);
-    this.getElement()
-        .executeJs(
-            "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').getElementsByTagName('vaadin-login-form-wrapper')[0].replaceChildren())");
+    this.getElement().executeJs(
+            LoginOverlayUtils.getLoginFormWrapperScript(
+                """
+                    formWrapper.querySelectorAll('[slot="form"], [slot="submit"], [slot="forgot-password"]').forEach(c => c.remove());
+                    """));
     this.getElement().appendChild(content.getElement());
     content.getElement().setAttribute("slot", "form");
-    this.content
-        .getElement()
-        .executeJs(
-            "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').getElementsByTagName('vaadin-login-form-wrapper')[0].appendChild(this))");
+    this.content.getElement().executeJs(
+            LoginOverlayUtils.getLoginFormWrapperScript(
+                """
+                    formWrapper.appendChild(this);
+                    """));
   }
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/LoginOverlayUtils.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/LoginOverlayUtils.java
@@ -30,6 +30,7 @@ class LoginOverlayUtils {
 
   /**
    * Generates a JavaScript snippet that finds the overlay wrapper element.
+   * Handles both Vaadin 24 and Vaadin 25+ compatibility.
    *
    * @param action the JavaScript code to execute on the overlay wrapper
    * @return the complete JavaScript string with the overlay wrapper lookup and
@@ -39,6 +40,13 @@ class LoginOverlayUtils {
     return """
         setTimeout(() => {
           var overlayWrapper = document.getElementById('vaadinLoginOverlayWrapper');
+          if (!overlayWrapper) {
+            var loginOverlay = document.querySelector('vaadin-login-overlay');
+            if (loginOverlay && loginOverlay.shadowRoot) {
+              overlayWrapper = loginOverlay.shadowRoot
+                .querySelector('vaadin-login-overlay-wrapper');
+            }
+          }
           if (!overlayWrapper) return;
           %s
         });
@@ -46,7 +54,8 @@ class LoginOverlayUtils {
   }
 
   /**
-   * Generates a JavaScript snippet that finds the form element.
+   * Generates a JavaScript snippet that finds the form element. Handles both
+   * Vaadin 24 and Vaadin 25+ compatibility.
    *
    * @param action the JavaScript code to execute on the form
    * @return the complete JavaScript string with the form lookup and the provided
@@ -56,6 +65,9 @@ class LoginOverlayUtils {
     return """
         setTimeout(() => {
           var overlayFormWrapper = document.getElementById('vaadinLoginOverlayWrapper');
+          if (!overlayFormWrapper) {
+            overlayFormWrapper = document.querySelector('vaadin-login-overlay');
+          }
           if (!overlayFormWrapper) return;
           var form = overlayFormWrapper.querySelector('form');
           if (form) {
@@ -67,7 +79,7 @@ class LoginOverlayUtils {
 
   /**
    * Generates a JavaScript snippet that finds the form wrapper containing form
-   * elements.
+   * elements. Handles both Vaadin 24 and Vaadin 25+ compatibility.
    *
    * @param action the JavaScript code to execute on the form wrapper
    * @return the complete JavaScript string with the form wrapper lookup and the
@@ -77,6 +89,13 @@ class LoginOverlayUtils {
     return """
         setTimeout(() => {
           var overlayWrapper = document.getElementById('vaadinLoginOverlayWrapper');
+          if (!overlayWrapper) {
+            var loginOverlay = document.querySelector('vaadin-login-overlay');
+            if (loginOverlay && loginOverlay.shadowRoot) {
+              overlayWrapper = loginOverlay.shadowRoot
+                .querySelector('vaadin-login-overlay-wrapper');
+            }
+          }
           if (!overlayWrapper) return;
           var formWrapper = overlayWrapper.querySelector('vaadin-login-form-wrapper');
           if (!formWrapper) return;

--- a/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/LoginOverlayUtils.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/LoginOverlayUtils.java
@@ -1,0 +1,88 @@
+/*-
+ * #%L
+ * Extended Login Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.extendedlogin;
+
+/**
+ * Utility class for LoginOverlay.
+ */
+class LoginOverlayUtils {
+
+  private LoginOverlayUtils() {
+    // Utility class
+  }
+
+  /**
+   * Generates a JavaScript snippet that finds the overlay wrapper element.
+   *
+   * @param action the JavaScript code to execute on the overlay wrapper
+   * @return the complete JavaScript string with the overlay wrapper lookup and
+   *         the provided action
+   */
+  static String getOverlayWrapperScript(String action) {
+    return """
+        setTimeout(() => {
+          var overlayWrapper = document.getElementById('vaadinLoginOverlayWrapper');
+          if (!overlayWrapper) return;
+          %s
+        });
+        """.formatted(action);
+  }
+
+  /**
+   * Generates a JavaScript snippet that finds the form element.
+   *
+   * @param action the JavaScript code to execute on the form
+   * @return the complete JavaScript string with the form lookup and the provided
+   *         action
+   */
+  static String getFormWrapperScript(String action) {
+    return """
+        setTimeout(() => {
+          var overlayFormWrapper = document.getElementById('vaadinLoginOverlayWrapper');
+          if (!overlayFormWrapper) return;
+          var form = overlayFormWrapper.querySelector('form');
+          if (form) {
+            %s
+          }
+        });
+        """.formatted(action);
+  }
+
+  /**
+   * Generates a JavaScript snippet that finds the form wrapper containing form
+   * elements.
+   *
+   * @param action the JavaScript code to execute on the form wrapper
+   * @return the complete JavaScript string with the form wrapper lookup and the
+   *         provided action
+   */
+  static String getLoginFormWrapperScript(String action) {
+    return """
+        setTimeout(() => {
+          var overlayWrapper = document.getElementById('vaadinLoginOverlayWrapper');
+          if (!overlayWrapper) return;
+          var formWrapper = overlayWrapper.querySelector('vaadin-login-form-wrapper');
+          if (!formWrapper) return;
+          %s
+        });
+        """.formatted(action);
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/ReplaceableLoginOverlay.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/extendedlogin/ReplaceableLoginOverlay.java
@@ -28,49 +28,104 @@ import com.vaadin.flow.component.HasElement;
  */
 public interface ReplaceableLoginOverlay extends HasElement {
 
+  /**
+   * Replaces the contents of the login form with the provided elements. Clears
+   * existing form
+   * contents and appends the provided elements.
+   *
+   * @param withElement the elements to add to the form
+   */
   default void replaceFormComponents(HasElement... withElement) {
-    this.getElement()
-        .executeJs(
-            "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').getElementsByTagName('vaadin-login-form-wrapper')[0].getElementsByTagName('form')[0].replaceChildren())");
+    this.getElement().executeJs(LoginOverlayUtils.getFormWrapperScript("form.replaceChildren();"));
+
     for (HasElement we : withElement) {
       getElement().appendChild(we.getElement());
       this.getElement()
-          .executeJs(
-              "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').getElementsByTagName('vaadin-login-form-wrapper')[0].getElementsByTagName('form')[0].appendChild($0))",
-              we.getElement());
+          .executeJs(LoginOverlayUtils.getFormWrapperScript("form.appendChild($0);"), we.getElement());
     }
   }
 
+  /**
+   * Replaces the header/brand component of the login overlay. Clears the brand
+   * section and appends
+   * the provided element.
+   *
+   * @param withElement the element to set as the new brand/header
+   */
   default void replaceHeaderComponent(HasElement withElement) {
     getElement().appendChild(withElement.getElement());
-    this.getElement()
-        .executeJs(
-            "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').shadowRoot.querySelector('[part=\"brand\"]').replaceChildren())");
-    this.getElement()
-        .executeJs(
-            "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').shadowRoot.querySelector('[part=\"brand\"]').appendChild($0))",
-            withElement);
-  }
 
-  default void replaceForgotPassword(HasElement withElement) {
-    withElement.getElement().setAttribute("slot", "forgot-password");
-    getElement().appendChild(withElement.getElement());
     this.getElement()
         .executeJs(
-            "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').getElementsByTagName('vaadin-login-form-wrapper')[0].querySelector('[slot=\\\"forgot-password\\\"]').remove())");
+            LoginOverlayUtils.getOverlayWrapperScript(
+                """
+                    var brand = overlayWrapper.shadowRoot ? overlayWrapper.shadowRoot.querySelector('[part="brand"]') : overlayWrapper.querySelector('[part="brand"]');
+                    if (brand) {
+                      brand.replaceChildren();
+                    }
+                    """));
+
     this.getElement()
         .executeJs(
-            "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').getElementsByTagName('vaadin-login-form-wrapper')[0].appendChild($0))",
+            LoginOverlayUtils.getOverlayWrapperScript(
+                """
+                    var brand = overlayWrapper.shadowRoot ? overlayWrapper.shadowRoot.querySelector('[part="brand"]') : overlayWrapper.querySelector('[part="brand"]');
+                    if (brand) {
+                      brand.appendChild($0);
+                    }
+                    """),
             withElement);
   }
 
   /**
-   * Removes the default submit button. 
+   * Removes the forgot password link from the login form.
+   */
+  default void removeForgotPassword() {
+    this.getElement()
+        .executeJs(
+            LoginOverlayUtils.getLoginFormWrapperScript(
+                """
+                    var forgotPassword = formWrapper.querySelector('[slot="forgot-password"]');
+                    if (forgotPassword) {
+                      forgotPassword.remove();
+                    }
+                    """));
+  }
+
+  /**
+   * Replaces the forgot password component in the login overlay. Clears the
+   * forgot password section
+   * and appends the provided element.
+   *
+   * @param withElement the element to set as the new forgot password component
+   *
+   */
+  default void replaceForgotPassword(HasElement withElement) {
+    withElement.getElement().setAttribute("slot", "forgot-password");
+    getElement().appendChild(withElement.getElement());
+    this.removeForgotPassword();
+    this.getElement()
+        .executeJs(
+            LoginOverlayUtils.getLoginFormWrapperScript(
+                """
+                    formWrapper.appendChild($0);
+                    """),
+            withElement);
+  }
+
+  /**
+   * Removes the default submit button.
    */
   default void removeSubmitButton() {
-      this.getElement()
-              .executeJs(
-                      "setTimeout(()=>document.getElementById('vaadinLoginOverlayWrapper').getElementsByTagName('vaadin-login-form-wrapper')[0].querySelector('[slot=\"submit\"]').remove())");
+    this.getElement()
+        .executeJs(
+            LoginOverlayUtils.getLoginFormWrapperScript(
+                """
+                    var submitButton = formWrapper.querySelector('[slot="submit"]');
+                    if (submitButton) {
+                      submitButton.remove();
+                    }
+                    """));
   }
- 
+
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/AppShellConfiguratorImpl.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/AppShellConfiguratorImpl.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * Extended Login Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons;
+
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.theme.Theme;
+
+@Theme
+public class AppShellConfiguratorImpl implements AppShellConfigurator {
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/ExtendedLoginOverlayDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/ExtendedLoginOverlayDemo.java
@@ -29,6 +29,12 @@ import com.vaadin.flow.router.Route;
 
 @DemoSource(
     "/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestExtendedLoginOverlayView.java")
+//#if vaadin eq 0
+@DemoSource(value = "/src/test/resources/META-INF/frontend/styles/extended-login-styles.css",
+    caption = "extended-login-styles.css", condition = "vaadin eq 24")
+@DemoSource(value = "/src/test/resources/META-INF/frontend/styles/extended-login-styles-v25.css",
+    caption = "extended-login-styles-v25.css", condition = "vaadin ge 25")
+//#endif
 @PageTitle("Extended Login Overlay Demo")
 @SuppressWarnings("serial")
 @Route(value = "extended-login/login-overlay-demo", layout = ExtendedLoginDemoView.class)

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/LoginLayoutDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/LoginLayoutDemo.java
@@ -29,6 +29,12 @@ import com.vaadin.flow.router.Route;
 
 @DemoSource("/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayoutView.java")
 @DemoSource("/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayout.java")
+//#if vaadin eq 0
+@DemoSource(value = "/src/test/resources/META-INF/frontend/styles/extended-login-styles.css",
+    caption = "extended-login-styles.css", condition = "vaadin eq 24")
+@DemoSource(value = "/src/test/resources/META-INF/frontend/styles/extended-login-styles-v25.css",
+    caption = "extended-login-styles-v25.css", condition = "vaadin ge 25")
+//#endif
 @PageTitle("Login Layout Demo")
 @SuppressWarnings("serial")
 @Route(value = "extended-login/login-layout-demo", layout = ExtendedLoginDemoView.class)

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestExtendedLoginOverlayView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestExtendedLoginOverlayView.java
@@ -39,7 +39,11 @@ import org.junit.Ignore;
  */
 @SuppressWarnings("serial")
 @Route(value = "extended-login/login-overlay")
-@CssImport("./styles/extended-login-styles.css") // hide-source
+//#if vaadin eq 24
+@CssImport("./styles/extended-login-styles.css")
+//#else
+@CssImport("./styles/extended-login-styles-v25.css")
+//#endif
 @Ignore
 public class TestExtendedLoginOverlayView extends Div {
 

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestExtendedLoginOverlayView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestExtendedLoginOverlayView.java
@@ -64,4 +64,5 @@ public class TestExtendedLoginOverlayView extends Div {
     elo.setOpened(true);
     add(elo);
   }
+
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayout.java
@@ -55,4 +55,5 @@ public class TestLoginLayout extends LoginLayout {
     i18n.setAdditionalInformation("Change your password");
     return i18n;
   }
+
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayoutView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayoutView.java
@@ -46,6 +46,9 @@ import com.vaadin.flow.router.Route;
 // show-source @Route("value = "extended-login/login-layout-demo", layout = TestLoginLayout.class)
 public class TestLoginLayoutView extends Div {
 
+  private PasswordField password;
+  private PasswordField confirmPassword;
+
   public TestLoginLayoutView() {
     add(createChangePasswordForm());
   }
@@ -53,9 +56,9 @@ public class TestLoginLayoutView extends Div {
   private FormLayout createChangePasswordForm() {
     TextField username = new TextField("Username");
     username.setEnabled(false);
-    PasswordField password = new PasswordField("Password");
-    PasswordField confirmPassword = new PasswordField("Confirm password");
-    Button accept = new Button("Accept", ev -> Notification.show("Password changed."));
+    password = new PasswordField("Password");
+    confirmPassword = new PasswordField("Confirm password");
+    Button accept = new Button("Accept", ev -> onAccept());
 
     FormLayout formLayout = new FormLayout();
     formLayout.add(username, password, confirmPassword, accept);
@@ -68,5 +71,15 @@ public class TestLoginLayoutView extends Div {
     formLayout.setColspan(username, 2);
     formLayout.setColspan(accept, 2);
     return formLayout;
+  }
+
+  private void onAccept() {
+    String passwordValue = this.password.getValue();
+    String confirmPasswordValue = this.confirmPassword.getValue();
+    if (passwordValue != null && !passwordValue.isBlank() && passwordValue.equals(confirmPasswordValue)) {
+      Notification.show("Password changed.");
+    } else {
+      Notification.show("Passwords do not match.");
+    }
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayoutView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/TestLoginLayoutView.java
@@ -38,7 +38,11 @@ import com.vaadin.flow.router.Route;
 @SuppressWarnings("serial")
 @Route(value = "extended-login/login-layout", layout = TestLoginLayout.class)
 @Ignore
-@CssImport("./styles/extended-login-styles.css") // hide-source
+//#if vaadin eq 24
+@CssImport("./styles/extended-login-styles.css")
+//#else
+@CssImport("./styles/extended-login-styles-v25.css")
+//#endif
 // show-source @Route("value = "extended-login/login-layout-demo", layout = TestLoginLayout.class)
 public class TestLoginLayoutView extends Div {
 

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/AbstractViewTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/AbstractViewTest.java
@@ -20,6 +20,7 @@
 
 package com.flowingcode.vaadin.addons.extendedlogin.it;
 
+import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
 import com.vaadin.testbench.ScreenshotOnFailureRule;
 import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.parallel.ParallelTest;
@@ -42,12 +43,14 @@ import org.openqa.selenium.chrome.ChromeDriver;
  * <p>To learn more about TestBench, visit <a
  * href="https://vaadin.com/docs/v10/testbench/testbench-overview.html">Vaadin TestBench</a>.
  */
-public abstract class AbstractViewTest extends ParallelTest {
+public abstract class AbstractViewTest extends ParallelTest implements HasRpcSupport {
   private static final int SERVER_PORT = 8080;
 
   private final String route;
 
   @Rule public ScreenshotOnFailureRule rule = new ScreenshotOnFailureRule(this, true);
+
+  ServerVersionCallables $server = createCallableProxy(ServerVersionCallables.class);
 
   public AbstractViewTest() {
     this("");
@@ -70,7 +73,8 @@ public abstract class AbstractViewTest extends ParallelTest {
     } else {
       setDriver(TestBench.createDriver(new ChromeDriver()));
     }
-    getDriver().get(getURL(route));
+    getDriver().get(getURL(route)); 
+    getCommandExecutor().waitForVaadin();
   }
 
   /**

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/ExtendedLoginOverlayIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/ExtendedLoginOverlayIT.java
@@ -26,16 +26,21 @@ import static org.junit.Assert.assertTrue;
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.component.html.testbench.AnchorElement;
+import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
+import com.vaadin.testbench.ElementQuery;
+
 import org.junit.Test;
 
 public class ExtendedLoginOverlayIT extends AbstractViewTest {
 
   public ExtendedLoginOverlayIT() {
-    super("extended-login/login-overlay");
+    super("it/extended-login/login-overlay");
   }
 
   @Test
-  public void testBasicBehaviour() {
+  public void testBasicBehaviour() {    
+    boolean vaadin25 = $server.getMajorVersion() >= 25; 
+
     boolean comboBoxExists = $(ComboBoxElement.class).exists();
     assertTrue("ComboBox not present", comboBoxExists);
     boolean buttonExists = $(ButtonElement.class).exists();
@@ -43,10 +48,13 @@ public class ExtendedLoginOverlayIT extends AbstractViewTest {
     if (buttonExists) {
       assertEquals("Sign In", $(ButtonElement.class).first().getText());
     }
-    boolean anchorExists = $(AnchorElement.class).exists();
+
+    ElementQuery<AnchorElement> anchorQuery = vaadin25 ? $(LoginOverlayElement.class).first().$(AnchorElement.class)
+        : $(AnchorElement.class);
+    boolean anchorExists = anchorQuery.exists();
     assertTrue("Anchor not present", anchorExists);
     if (anchorExists) {
-      assertEquals("Flowing Code Site", $(AnchorElement.class).first().getText());
+      assertEquals("Flowing Code Site", anchorQuery.first().getText());
     }
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/LoginLayoutIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/LoginLayoutIT.java
@@ -28,31 +28,46 @@ import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.H2Element;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import org.junit.Test;
+import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
 
 public class LoginLayoutIT extends AbstractViewTest {
 
   public LoginLayoutIT() {
-    super("extended-login/login-layout");
+    super("it/extended-login/login-layout");
   }
 
   @Test
   public void testBasicBehaviour() {
-    VaadinLoginOverlayWrapperElement vlow = $(VaadinLoginOverlayWrapperElement.class).first();
-    VaadinLoginFormWrapperElement vlfw = $(VaadinLoginFormWrapperElement.class).first();
+    boolean vaadin25 = $server.getMajorVersion() >= 25;
+
+    LoginOverlayElement vlo = $(LoginOverlayElement.class).first();
+    TestBenchElement vlow = vaadin25 ? vlo.getLoginOverlayWrapper() : $(VaadinLoginOverlayWrapperElement.class).first();
+    TestBenchElement vlfw = vaadin25 ? vlo.$("vaadin-login-form-wrapper").first()
+        : $(VaadinLoginFormWrapperElement.class).first();
+
     assertTrue(
         "Custom image is not present",
         vlow.$(ImageElement.class).attribute("alt", "Login image").exists());
-    boolean h2exists = vlfw.$(H2Element.class).exists();
-    assertTrue("H2 is not present", h2exists);
-    if (h2exists) {
-      assertEquals("Change Password", vlfw.$(H2Element.class).first().getText());
+
+    if (vaadin25) {
+      assertEquals("Change Password", vlo.getFormTitle());
+    } else {
+      boolean h2exists = vlfw.$(H2Element.class).exists();
+      assertTrue("H2 is not present", h2exists);
+      if (h2exists) {
+        assertEquals("Change Password", vlfw.$(H2Element.class).first().getText());
+      }
     }
-    boolean divSlotFormExists = $(DivElement.class).attribute("slot", "form").exists();
+
+    ElementQuery<DivElement> divSlotForm = vlfw.$(DivElement.class).attribute("slot", "form");
+    boolean divSlotFormExists = divSlotForm.exists();
     assertTrue("Div with slot form is not present", divSlotFormExists);
     if (divSlotFormExists) {
-      boolean divContainsFormLayoutExists =
-          $(DivElement.class).attribute("slot", "form").first().$(FormLayoutElement.class).exists();
+      boolean divContainsFormLayoutExists = divSlotForm.first().$(FormLayoutElement.class).exists();
       assertTrue("Div does not contain form layout", divContainsFormLayoutExists);
     }
   }
+
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/ServerVersionCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/ServerVersionCallables.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * Extended Login Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.extendedlogin.it;
+
+/**
+ * Interface for callable methods to retrieve server version information. This
+ * is used to determine whether certain tests should be executed based on the
+ * server version.
+ */
+public interface ServerVersionCallables {
+
+  int getMajorVersion();
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/TestExtendedLoginOverlayIntegrationView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/TestExtendedLoginOverlayIntegrationView.java
@@ -1,0 +1,38 @@
+/*-
+ * #%L
+ * Extended Login Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.extendedlogin.it;
+
+import com.flowingcode.vaadin.addons.extendedlogin.TestExtendedLoginOverlayView;
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Integration test view for {@link TestExtendedLoginOverlayView}.
+ */
+@Route("it/extended-login/login-overlay")
+public class TestExtendedLoginOverlayIntegrationView extends TestExtendedLoginOverlayView implements ServerVersionCallables {
+
+  @Override
+  @ClientCallable
+  public int getMajorVersion() {
+    return com.vaadin.flow.server.Version.getMajorVersion();
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/TestLoginLayoutIntegration.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/TestLoginLayoutIntegration.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * Extended Login Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.extendedlogin.it;
+
+import com.flowingcode.vaadin.addons.extendedlogin.TestLoginLayout;
+import com.vaadin.flow.component.ClientCallable;
+
+/**
+ * Integration test view for {@link TestLoginLayout}.
+ */
+public class TestLoginLayoutIntegration extends TestLoginLayout
+    implements ServerVersionCallables {
+
+  @Override
+  @ClientCallable
+  public int getMajorVersion() {
+    return com.vaadin.flow.server.Version.getMajorVersion();
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/TestLoginLayoutIntegrationView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/extendedlogin/it/TestLoginLayoutIntegrationView.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * Extended Login Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.extendedlogin.it;
+
+import com.flowingcode.vaadin.addons.extendedlogin.TestLoginLayout;
+import com.flowingcode.vaadin.addons.extendedlogin.TestLoginLayoutView;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Integration test view for {@link TestLoginLayout}.
+ */
+@Route(value = "it/extended-login/login-layout", layout = TestLoginLayoutIntegration.class)
+public class TestLoginLayoutIntegrationView extends TestLoginLayoutView {
+
+}

--- a/src/test/resources/META-INF/frontend/styles/extended-login-styles-v25.css
+++ b/src/test/resources/META-INF/frontend/styles/extended-login-styles-v25.css
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * Extended Login Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/*Demo styles*/
+vaadin-login-overlay::part(brand) {
+  background: black;
+  justify-content: center;
+  align-content: center;
+  flex-wrap: wrap;
+}
+
+@media only screen and (max-height: 600px) and (min-width: 600px) and (orientation: landscape) {
+	vaadin-login-overlay::part(form) {
+		overflow: initial;
+	}
+}
+
+vaadin-login-overlay::part(content) {
+  transform: scale(0.75);
+}
+
+.wrap-iframe {
+  overflow: hidden;
+}


### PR DESCRIPTION
This PR adds Vaadin 25 compatibility while maintaining support for Vaadin 24, along with several refactorings and demo improvements. (Rebased from #27)

**Changes:**

**Vaadin 24 & 25 compatibility**
* Updated JavaScript calls in ReplaceableLoginOverlay and LoginLayout to support both Vaadin 24 and Vaadin 25.
* Adjusted tests to work with both versions.
* Added testbench-rpc dependency to retrieve the Vaadin version during tests.

**Code improvements**
* Refactored JavaScript snippets to use Java text blocks for improved readability.
* Moved static methods from ReplaceableLoginOverlay  interface into a dedicated utils class.

**Demo improvements**
* Added AppShellConfiguratorImpl class.
* Introduced separate stylesheets for Vaadin 25 compatibility.
* Used the demo source condition attribute to switch between Vaadin 24 and 25 styles.
* Added simple change password validation in the demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added login overlay customization methods for replacing header/form, removing/replacing forgot-password and removing the submit button.

* **Improvements**
  * Faster, more reliable login overlay DOM updates for improved UI responsiveness.
  * Demo and stylesheet additions with Vaadin-version-specific CSS for better appearance on different framework versions.

* **Chores**
  * Updated Vaadin to 25.0.6 and added test infrastructure and test dependency support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->